### PR TITLE
Update dashboard links to skillscan.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This could be expanded along both axes -- adding more scanners and targeting mor
 | autonomy_abuse | 7 |
 | obfuscation | 5 |
 
-- These results are visualized at [skillscan.appsechq.com](https://skillscan.appsechq.com/). See [summary-report.md](results/summary-report.md) for detailed findings by skill, severity breakdowns, and top risks. Per-skill scan results (JSON + Markdown) are in the [`results/`](results/) directory.
+- These results are visualized at [skillscan.io](https://skillscan.io/). See [summary-report.md](results/summary-report.md) for detailed findings by skill, severity breakdowns, and top risks. Per-skill scan results (JSON + Markdown) are in the [`results/`](results/) directory.
 <!-- END SCAN RESULTS -->
 
 ## Getting Started
@@ -153,7 +153,7 @@ Cloned skill repositories are kept in `skills/` locally but excluded from versio
 
 ## Links
 
-- [skillscan.appsechq.com](https://skillscan.appsechq.com/) -- interactive dashboard of scan results
+- [skillscan.io](https://skillscan.io/) -- interactive dashboard of scan results
 - [Cisco AI Defense skill-scanner](https://github.com/cisco-ai-defense/skill-scanner)
 - [skills.sh](https://skills.sh/)
 - [clawhub.ai](https://clawhub.ai/)


### PR DESCRIPTION
## Summary
- Update dashboard links in README.md from `skillscan.appsechq.com` to `skillscan.io`
- Both the scan results section and the Links section are updated

## Test plan
- [ ] Verify both links in the rendered README point to https://skillscan.io/

https://claude.ai/code/session_016z1Ww5Yg9PwmDWCuDm3ipz