### PR TITLE
Add README badges for license, Python, scan count, and site

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This could be expanded along both axes -- adding more scanners and targeting mor
 | autonomy_abuse | 7 |
 | obfuscation | 5 |
 
-- These results are visualized at [skillscan.appsechq.com](https://skillscan.appsechq.com/). See [summary-report.md](results/summary-report.md) for detailed findings by skill, severity breakdowns, and top risks. Per-skill scan results (JSON + Markdown) are in the [`results/`](results/) directory.
+- These results are visualized at [skillscan.io](https://skillscan.io/). See [summary-report.md](results/summary-report.md) for detailed findings by skill, severity breakdowns, and top risks. Per-skill scan results (JSON + Markdown) are in the [`results/`](results/) directory.
 <!-- END SCAN RESULTS -->
 
 ## Getting Started
@@ -153,7 +153,7 @@ Cloned skill repositories are kept in `skills/` locally but excluded from versio
 
 ## Links
 
-- [skillscan.appsechq.com](https://skillscan.appsechq.com/) -- interactive dashboard of scan results
+- [skillscan.io](https://skillscan.io/) -- interactive dashboard of scan results
 - [Cisco AI Defense skill-scanner](https://github.com/cisco-ai-defense/skill-scanner)
 - [skills.sh](https://skills.sh/)
 - [clawhub.ai](https://clawhub.ai/)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Skill Scanner Test
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![Skills Scanned](https://img.shields.io/badge/skills%20scanned-616-orange.svg)](https://skillscan.io)
+[![Website](https://img.shields.io/badge/site-skillscan.io-blue)](https://skillscan.io)
+
 An automated security scanning pipeline for AI agent skills and plugins in public skill directories.
 
 AI agent skills -- installable packages that extend what coding assistants and AI agents can do -- are a growing attack surface. Skills can contain prompt injection, data exfiltration, command injection, and other vulnerabilities, whether introduced intentionally or by accident. This project systematically scans public skills using Cisco's open-source [skill-scanner](https://github.com/cisco-ai-defense/skill-scanner) and publishes the results.


### PR DESCRIPTION
## Summary
- Add shields.io badges to the top of README.md: MIT license, Python 3.10+, skills scanned count, and skillscan.io site link

## Test plan
- [ ] Verify badges render correctly in the GitHub README preview
- [ ] Verify badge links point to the correct destinations

https://claude.ai/code/session_016z1Ww5Yg9PwmDWCuDm3ipz